### PR TITLE
Add launch.config for VSCode users

### DIFF
--- a/Source/Azure/AzureIoTHub/.vscode/launch.config
+++ b/Source/Azure/AzureIoTHub/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/DevCamp 2020/TemperatureDisplay/.vscode/launch.config
+++ b/Source/DevCamp 2020/TemperatureDisplay/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/DeveloperDay2021/01-GettingStarted/Code/.vscode/launch.config
+++ b/Source/DeveloperDay2021/01-GettingStarted/Code/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/DeveloperDay2021/02-LightSensor/Code/.vscode/launch.config
+++ b/Source/DeveloperDay2021/02-LightSensor/Code/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/DeveloperDay2021/03-MarsRover/Code/.vscode/launch.config
+++ b/Source/DeveloperDay2021/03-MarsRover/Code/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/DeveloperSouthCoast2022/01-GettingStarted/Code/.vscode/launch.config
+++ b/Source/DeveloperSouthCoast2022/01-GettingStarted/Code/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/DeveloperSouthCoast2022/02-LightSensor/Code/.vscode/launch.config
+++ b/Source/DeveloperSouthCoast2022/02-LightSensor/Code/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Games/Frogger/Frogger/.vscode/launch.config
+++ b/Source/Games/Frogger/Frogger/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Games/Span4/Span4_SSD1309/.vscode/launch.config
+++ b/Source/Games/Span4/Span4_SSD1309/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Games/Span4/Span4_ST7789/.vscode/launch.config
+++ b/Source/Games/Span4/Span4_ST7789/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Games/Tetris/Tetris/.vscode/launch.config
+++ b/Source/Games/Tetris/Tetris/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Games/Tetris/Tetris_Max7219/.vscode/launch.config
+++ b/Source/Games/Tetris/Tetris_Max7219/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/Bluetooth/MeadowBleLed/.vscode/launch.config
+++ b/Source/Hackster/Bluetooth/MeadowBleLed/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/Bluetooth/MeadowBleServo/.vscode/launch.config
+++ b/Source/Hackster/Bluetooth/MeadowBleServo/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/Bluetooth/MeadowBleTemperature/.vscode/launch.config
+++ b/Source/Hackster/Bluetooth/MeadowBleTemperature/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/ChristmasCountdown/.vscode/launch.config
+++ b/Source/Hackster/ChristmasCountdown/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/EdgeASketch/.vscode/launch.config
+++ b/Source/Hackster/EdgeASketch/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/GalleryViewer/.vscode/launch.config
+++ b/Source/Hackster/GalleryViewer/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/LedDice/.vscode/launch.config
+++ b/Source/Hackster/LedDice/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/LedJoystick/.vscode/launch.config
+++ b/Source/Hackster/LedJoystick/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/LedSample/.vscode/launch.config
+++ b/Source/Hackster/LedSample/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/Maple/MeadowMapleLed/.vscode/launch.config
+++ b/Source/Hackster/Maple/MeadowMapleLed/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/Maple/MeadowMapleServo/.vscode/launch.config
+++ b/Source/Hackster/Maple/MeadowMapleServo/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/Maple/MeadowMapleTemperature/.vscode/launch.config
+++ b/Source/Hackster/Maple/MeadowMapleTemperature/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/Maple/MobileMaple/.vscode/launch.config
+++ b/Source/Hackster/Maple/MobileMaple/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/McpLedBarGraph/.vscode/launch.config
+++ b/Source/Hackster/McpLedBarGraph/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/McpLeds/.vscode/launch.config
+++ b/Source/Hackster/McpLeds/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/MeadowClock/.vscode/launch.config
+++ b/Source/Hackster/MeadowClock/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/MeadowClockGraphics/.vscode/launch.config
+++ b/Source/Hackster/MeadowClockGraphics/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/MeadowMenu/.vscode/launch.config
+++ b/Source/Hackster/MeadowMenu/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/MemoryGame/.vscode/launch.config
+++ b/Source/Hackster/MemoryGame/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/MerryXmasLights/.vscode/launch.config
+++ b/Source/Hackster/MerryXmasLights/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/MoistureMeter/.vscode/launch.config
+++ b/Source/Hackster/MoistureMeter/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/MorseCodeTrainer/.vscode/launch.config
+++ b/Source/Hackster/MorseCodeTrainer/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/MotionDetector/.vscode/launch.config
+++ b/Source/Hackster/MotionDetector/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/MotorRotaryController/.vscode/launch.config
+++ b/Source/Hackster/MotorRotaryController/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/Mp3Player/.vscode/launch.config
+++ b/Source/Hackster/Mp3Player/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/ObstacleRadar/.vscode/launch.config
+++ b/Source/Hackster/ObstacleRadar/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/PlantMonitor/.vscode/launch.config
+++ b/Source/Hackster/PlantMonitor/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/RadioPlayer/.vscode/launch.config
+++ b/Source/Hackster/RadioPlayer/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/RgbLedSample/.vscode/launch.config
+++ b/Source/Hackster/RgbLedSample/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/RotaryLedBar/.vscode/launch.config
+++ b/Source/Hackster/RotaryLedBar/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/RotaryServo/.vscode/launch.config
+++ b/Source/Hackster/RotaryServo/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/RotationDetector/.vscode/launch.config
+++ b/Source/Hackster/RotationDetector/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/Rover/MeadowBleRover/.vscode/launch.config
+++ b/Source/Hackster/Rover/MeadowBleRover/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/Rover/MeadowLedRover/.vscode/launch.config
+++ b/Source/Hackster/Rover/MeadowLedRover/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/ServoButton/.vscode/launch.config
+++ b/Source/Hackster/ServoButton/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/ShiftRegisterLeds/.vscode/launch.config
+++ b/Source/Hackster/ShiftRegisterLeds/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/Simon/.vscode/launch.config
+++ b/Source/Hackster/Simon/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/StopwatchDisplay/.vscode/launch.config
+++ b/Source/Hackster/StopwatchDisplay/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/TemperatureMonitor/.vscode/launch.config
+++ b/Source/Hackster/TemperatureMonitor/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/TouchKeypad/.vscode/launch.config
+++ b/Source/Hackster/TouchKeypad/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/WifiClock/.vscode/launch.config
+++ b/Source/Hackster/WifiClock/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/WifiWeather/.vscode/launch.config
+++ b/Source/Hackster/WifiWeather/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Hackster/WifiWeatherClock/.vscode/launch.config
+++ b/Source/Hackster/WifiWeatherClock/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Microsoft_IoT/RaiseTheFlag/RaiseTheFlagMeadow/.vscode/launch.config
+++ b/Source/Microsoft_IoT/RaiseTheFlag/RaiseTheFlagMeadow/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}


### PR DESCRIPTION
Part of WildernessLabs/Meadow_Issues#236.

The addition of the `.vscode` folder doesn't appear to impact VS2022 users at all, even with several folders present in a solution.  I confirmed expected debug behavior using only the Blinky C# project, but it worked as expected.